### PR TITLE
Add combined `Event`s support (#5)

### DIFF
--- a/\
+++ b/\
@@ -17,16 +17,8 @@ type VersionedEvent[E any] struct {
 	Ver Version
 }
 
-// EventSet is object which is used to combine multiple AppliableEvent's. It's usable to return this object
-// from Command with events stored in it. It applies AppliableEvent iterface.
-type EventSet[Agg Aggregate[ID], ID comparable, Ev AppliableEvent[Agg, ID]] struct {
+type EventSet[Agg Aggregate[ID], ID any, Ev AppliableEvent[Agg, ID]] struct {
 	Events []Ev
-}
-
-func NewSet[Agg Aggregate[ID], ID comparable, Ev AppliableEvent[Agg, ID]](evs []Ev) EventSet[Agg, ID, Ev] {
-	return EventSet[Agg, ID, Ev]{
-		Events: evs,
-	}
 }
 
 func (es *EventSet[Agg, Id, Ev]) ApplyTo(agg Agg) {
@@ -38,8 +30,8 @@ func (es *EventSet[Agg, Id, Ev]) ApplyTo(agg Agg) {
 func (es *EventSet[Agg, ID, Ev]) GetRelatedId() ID {
 	id := es.Events[0].GetRelatedId()
 	for _, ev := range es.Events {
-		evId := ev.GetRelatedId()
-		if evId != id {
+		ev_id := ev.GetRelatedId()
+		if ev_id != id {
 			panic("events have incompatible Id's")
 		}
 	}

--- a/examples/account/command/create_account_test.go
+++ b/examples/account/command/create_account_test.go
@@ -13,13 +13,19 @@ func TestEmitsCreated(t *testing.T) {
 		Owner: "test",
 	}
 	ev, _ := cmd.ExecuteCommand(&acc)
-	created, ok := ev.(*event.AccountCreated)
+	evs, ok := ev.(*account.EventSet)
 	if !ok {
 		t.Errorf("Wrong event type returned")
 	}
 
+	created := evs.Events[0].(*event.AccountCreated)
 	if created.Owner != cmd.Owner {
 		t.Errorf("Expected owner to be '%s', got '%s'", cmd.Owner, created.Owner)
+	}
+
+	activated := evs.Events[1].(*event.AccountActivated)
+	if activated.AccountId != created.AccountId {
+		t.Errorf("Expected id to be '%d', got '%d'", created.AccountId, activated.AccountId)
 	}
 }
 
@@ -34,13 +40,18 @@ func TestHandleCreateAccount(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 
-	created, ok := ev.(*event.AccountCreated)
+	evs, ok := ev.(*account.EventSet)
 	if !ok {
 		t.Errorf("Wrong event type returned")
 	}
 
+	created := evs.Events[0].(*event.AccountCreated)
 	if created.Owner != cmd.Owner {
 		t.Errorf("Expected owner to be '%s', got '%s'", cmd.Owner, created.Owner)
+	}
+	activated := evs.Events[1].(*event.AccountActivated)
+	if activated.AccountId != created.AccountId {
+		t.Errorf("Expected id to be '%d', got '%d'", created.AccountId, activated.AccountId)
 	}
 
 	if agg.Owner != cmd.Owner {

--- a/examples/account/domain/account.go
+++ b/examples/account/domain/account.go
@@ -5,11 +5,12 @@ import (
 )
 
 type Account struct {
-	Id        AccountId
-	Owner     AccountOwner
-	Balance   AccountBalance
-	CreatedAt CreationTime
-	DeletedAt DeletionTime
+	Id          AccountId
+	Owner       AccountOwner
+	Balance     AccountBalance
+	ActivatedAt ActivationTime
+	CreatedAt   CreationTime
+	DeletedAt   DeactivationTime
 }
 
 // AccountId is Account's identifier. It uniquely identifies it.
@@ -29,11 +30,15 @@ type AccountBalance int
 // AccountOwner is Account's owner name.
 type AccountOwner string
 
+// ActivationTime is the time account was activated.
+type ActivationTime string
+
 // CreationTime is the time Account was created.
 type CreationTime string
 
-// DeletionTime is the time Account was deleted.
-type DeletionTime string
+// DeactivationTime is the time Account was deactivated. Account's are never deleted to
+// save data.
+type DeactivationTime string
 
 func (a *Account) GetId() AccountId {
 	return a.Id

--- a/examples/account/event/account.go
+++ b/examples/account/event/account.go
@@ -2,6 +2,19 @@ package event
 
 import "cqrs-es/examples/account/domain"
 
+type AccountActivated struct {
+	AccountId domain.AccountId
+	At        domain.ActivationTime
+}
+
+func (ev *AccountActivated) ApplyTo(agg *domain.Account) {
+	agg.ActivatedAt = ev.At
+}
+
+func (ev *AccountActivated) GetRelatedId() domain.AccountId {
+	return ev.AccountId
+}
+
 type AccountCreated struct {
 	AccountId domain.AccountId
 	Owner     domain.AccountOwner
@@ -12,6 +25,7 @@ func (ev *AccountCreated) ApplyTo(agg *domain.Account) {
 	agg.Id = ev.AccountId
 	agg.Owner = ev.Owner
 	agg.Balance = 0
+	agg.ActivatedAt = ""
 	agg.CreatedAt = ev.At
 	agg.DeletedAt = ""
 }
@@ -58,18 +72,18 @@ func (ev *AccountWithdrawal) GetRelatedId() domain.AccountId {
 	return ev.AccountId
 }
 
-type AccountDeleted struct {
+type AccountDeactivated struct {
 	AccountId domain.AccountId
-	At        domain.DeletionTime
+	At        domain.DeactivationTime
 }
 
-func (ev *AccountDeleted) ApplyTo(agg *domain.Account) {
+func (ev *AccountDeactivated) ApplyTo(agg *domain.Account) {
 	if ev.AccountId != agg.Id {
 		panic("`AccountId` mismatch")
 	}
 	agg.DeletedAt = ev.At
 }
 
-func (ev *AccountDeleted) GetRelatedId() domain.AccountId {
+func (ev *AccountDeactivated) GetRelatedId() domain.AccountId {
 	return ev.AccountId
 }

--- a/examples/account/service.go
+++ b/examples/account/service.go
@@ -24,6 +24,16 @@ type Command pkg.Command[*domain.Account, domain.AccountId, Event]
 
 type Event pkg.AppliableEvent[*domain.Account, domain.AccountId]
 
+type EventSet struct {
+	pkg.EventSet[*domain.Account, domain.AccountId, Event]
+}
+
+func NewSet(evs []Event) EventSet {
+	return EventSet{
+		pkg.NewSet(evs),
+	}
+}
+
 func (s Service) HandleCommand(cmd Command) (domain.Account, Event, error) {
 	repo := s.Repo
 

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,11 +1,13 @@
 package repository
 
-type AggregateStorage[Agg Aggregate[ID], ID any] interface {
+import "cqrs-es/pkg"
+
+type AggregateStorage[Agg pkg.Aggregate[ID], ID any] interface {
 	SaveAggregate(agg Agg) error
 
 	LoadAggregate(id ID) (Agg, error)
 }
 
-type EventStorage[Ev AppliableEvent[Agg, ID], Agg Aggregate[ID], ID any] interface {
+type EventStorage[Ev pkg.AppliableEvent[Agg, ID], Agg pkg.Aggregate[ID], ID any] interface {
 	SaveEvent(ev Ev) error
 }


### PR DESCRIPTION
Resolves #5


## Issue description

`Command` interface returns `AppliableEvent`. Way to return multiple `Event`s  must be implemented.




## Solution

Implemented `EventSet` type.




## Checklist

- Created PR:
    - [x] Name contains issue reference
    - [x] Has `type: ` and `kind: ` labels applied
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Final commit message is posted
    - [x] and approved
- [x] review is completed and changes are approved
- Before merge:
    - [x] Commits are squashed and rebased
    - [x] Milestone is set
    - [x] MR's name and description are correct and up-to-date
    - [x] All temporary labels are removed